### PR TITLE
Remove: node_modules

### DIFF
--- a/generators/npm/templates/npmignore
+++ b/generators/npm/templates/npmignore
@@ -1,4 +1,3 @@
-node_modules
 *.log
 src
 coverage


### PR DESCRIPTION
You do not need `node_modules` in `.npmignore` because everything in node_modules is ignored. 

> Additionally, everything in node_modules is ignored, except for bundled dependencies. npm automatically handles this for you, so don't bother adding node_modules to .npmignore.

ref: https://docs.npmjs.com/misc/developers
